### PR TITLE
Implemented DbalReader

### DIFF
--- a/Reader/DbalReader.php
+++ b/Reader/DbalReader.php
@@ -1,0 +1,60 @@
+<?php
+namespace Ddeboer\DataImportBundle\Reader;
+
+use Doctrine\DBAL\Connection;
+use Ddeboer\DataImportBundle\Reader;
+
+abstract class DbalReader implements Reader
+{
+    protected $connection;
+    protected $schemaManager;
+    protected $table;
+    protected $data;
+    
+    public function __construct(Connection $connection, $table) 
+    {
+        $this->connection = $connection;
+        $this->schemaManager = $connection->getSchemaManager();
+        $this->table = $table;
+        $this->loadData();
+    }
+    
+    abstract function loadData();
+
+    public function getFields()
+    {
+        $fields = array();
+        
+        foreach ($this->schemaManager->listTableColumns($this->table) as $column) {
+            $fields[] = $column->getName();
+        }
+        
+        return $fields;
+    }
+    
+    public function current()
+    {
+        return current($this->data);
+    }
+    
+    public function next()
+    {
+        next($this->data);
+    }
+    
+    public function key()
+    {
+        return key($this->data);
+    }
+    
+    public function valid()
+    {
+        $key = key($this->data);
+        return ($key !== null && $key !== false);
+    }
+    
+    public function rewind()
+    {
+        reset($this->data);
+    }    
+}

--- a/Reader/DbalReader.php
+++ b/Reader/DbalReader.php
@@ -4,7 +4,7 @@ namespace Ddeboer\DataImportBundle\Reader;
 use Doctrine\DBAL\Connection;
 use Ddeboer\DataImportBundle\Reader;
 
-abstract class DbalReader implements Reader
+class DbalReader implements Reader
 {
     protected $connection;
     protected $schemaManager;
@@ -19,7 +19,10 @@ abstract class DbalReader implements Reader
         $this->loadData();
     }
     
-    abstract function loadData();
+    protected function loadData()
+    {
+        $this->data = $this->connection->fetchAll('SELECT * FROM ' . $this->table);    
+    }
 
     public function getFields()
     {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,12 @@
                  abstract="true">
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
+        
+        <service id="ddeboer_data_import.reader.doctrine_dbal" 
+                 class="Ddeboer\DataImportBundle\Reader\DbalReader"
+                 abstract="true">
+            <argument type="service" id="database_connection" />
+        </service>
 
         <service id="ddeboer_data_import.writer.doctrine"
                  class="Ddeboer\DataImportBundle\Writer\DoctrineWriter"

--- a/Workflow.php
+++ b/Workflow.php
@@ -211,6 +211,12 @@ class Workflow
                 }
             }
         }
+        
+        foreach ($this->writers as $writer) {
+            if ($writer instanceof Writer) {
+                $writer->finish();
+            }
+        }
     }
 
     /**

--- a/Writer/DoctrineWriter.php
+++ b/Writer/DoctrineWriter.php
@@ -212,12 +212,18 @@ class DoctrineWriter extends AbstractWriter
             }
         }
 
+        $this->prePersist($entity, $item);
         $this->entityManager->persist($entity);
 
         if (($this->counter % $this->batchSize) == 0) {
             $this->entityManager->flush();
             $this->entityManager->clear();
         }
+    }
+    
+    protected function prePersist($entity, array $item)
+    {
+        
     }
 
     /**

--- a/Writer/DoctrineWriter.php
+++ b/Writer/DoctrineWriter.php
@@ -142,6 +142,13 @@ class DoctrineWriter extends AbstractWriter
         
         return new $className;
     }
+    
+    protected function setValue($entity, $value, $setter) 
+    {
+        if (method_exists($entity, $setter)) {
+            $entity->$setter($value);
+        }
+    }
 
     /**
      * Re-enable Doctrine logging
@@ -201,9 +208,7 @@ class DoctrineWriter extends AbstractWriter
                 ))
             {
                 $setter = 'set' . ucfirst($fieldName);
-                if (method_exists($entity, $setter)) {
-                    $entity->$setter($value);
-                }            
+                $this->setValue($entity, $value, $setter);
             }
         }
 

--- a/Writer/DoctrineWriter.php
+++ b/Writer/DoctrineWriter.php
@@ -133,6 +133,15 @@ class DoctrineWriter extends AbstractWriter
 
         return $this;
     }
+    
+    protected function getNewInstance($className, array $item)
+    {
+        if (class_exists($className) === false) {
+            throw new \Exception('Unable to create new instance of ' . $className);    
+        }
+        
+        return new $className;
+    }
 
     /**
      * Re-enable Doctrine logging
@@ -170,7 +179,7 @@ class DoctrineWriter extends AbstractWriter
 
         if (!$entity) {
             $className = $this->entityMetadata->getName();
-            $entity = new $className;
+            $entity = $this->getNewInstance($className, $item);
         }
 
         foreach ($this->entityMetadata->getFieldNames() as $fieldName) {

--- a/Writer/DoctrineWriter.php
+++ b/Writer/DoctrineWriter.php
@@ -214,6 +214,7 @@ class DoctrineWriter extends AbstractWriter
 
         $this->prePersist($entity, $item);
         $this->entityManager->persist($entity);
+        $this->postPersist($entity, $item);
 
         if (($this->counter % $this->batchSize) == 0) {
             $this->entityManager->flush();
@@ -224,6 +225,11 @@ class DoctrineWriter extends AbstractWriter
     protected function prePersist($entity, array $item)
     {
         
+    }
+    
+    protected function postPersist($entity, array $item)
+    {
+    
     }
 
     /**


### PR DESCRIPTION
This PR adds a DbalReader to read data from a SQL Database without the doctrine orm layer.

Additionally, i've moved the new instance creation of the entity and the setter call in the `DoctrineWriter` to separate methods to ease overriding.

Usecase for the `new $className` refactoring: sometimes you want a service create the instances, for example in the `FosUserBundle` you use a `manipulator` service:

``` php
<?php

    protected function getNewInstance($className, array $item)
    {
        $password = $this->generatePasswordSomehow();
        return $this->userManipulator->create($item['username'], $password, $item['email'], false, false);
    }



```

As for the `setter` refactoring, you'll probably want to do some additional logic when setting a field:

``` php
<?php 

    protected function setValue($entity, $value, $setter)
    {
        if ($setter === 'setDescription') {
            $entity->translate('de')->setDescription($value['de']);
            $entity->translate('en')->setDescription($value['en']);
            $entity->setDescription('');
            return;
        }

        parent::setValue($entity, $value, $setter);
    }
```

The PR contains also a bugfix (34371ae) which adds the missing calls to the `finish` method of writer.
